### PR TITLE
SLB-267: Persisted query cache corruption

### DIFF
--- a/src/EventSubscriber/FixGraphQLCachingSubscriber.php
+++ b/src/EventSubscriber/FixGraphQLCachingSubscriber.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Drupal\silverback_graphql_persisted\EventSubscriber;
 
 use Drupal\graphql\Event\OperationEvent;
@@ -7,21 +8,28 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 /**
  * Fix GraphQL caching when internal page cache is active:
  *
- * TODO:
+ * @todo
  * Can be removed when https://github.com/drupal-graphql/graphql/pull/1317 is
  * resolved.
  */
 class FixGraphQLCachingSubscriber implements EventSubscriberInterface {
 
+  /**
+   *
+   */
   public function onBeforeOperation(OperationEvent $event): void {
     $event->getContext()->addCacheContexts(
-      ['url.query_args:variables', 'url.query_args:extensions']
+      ['url.query_args:queryId', 'url.query_args:variables', 'url.query_args:extensions']
     );
   }
 
+  /**
+   *
+   */
   public static function getSubscribedEvents() {
     return [
       OperationEvent::GRAPHQL_OPERATION_BEFORE => 'onBeforeOperation',
     ];
   }
+
 }


### PR DESCRIPTION
Fixes an issue where a persisted query suddenly returned the result of a different query. Both queries involved used exactly the same parameters, and changing a parameter in one of them fixed the issue. This suggests that the page cache metadata in persisted queries only includes the variables, but not the query id.

A proper fix (with tests included) is coming for the contributed graphql module.